### PR TITLE
Bugfixes

### DIFF
--- a/kubernetes-cncf/module-2/step1.md
+++ b/kubernetes-cncf/module-2/step1.md
@@ -1,4 +1,4 @@
-Let's pull down the Heptio Velero GitHub repo to help us get started: `git clone https://github.com/heptio/velero`{{execute}}
+Let's pull down the Heptio Velero GitHub repo to help us get started: `git clone --single-branch --branch release-0.11 https://github.com/heptio/velero`{{execute}}
 
 Apply some basic prerequisites (e.g. CustomResourceDefinitions, namespaces, and RBAC): `kubectl apply -f velero/examples/common/00-prereqs.yaml`{{execute}}
 

--- a/kubernetes-cncf/module-3/index.json
+++ b/kubernetes-cncf/module-3/index.json
@@ -45,7 +45,7 @@
     }
   },
   "files": [
-    "prometheus.yml"
+    "resources/prometheus.yml"
   ],
   "environment": {
     "showdashboard": true,

--- a/kubernetes-cncf/module-4/intro.md
+++ b/kubernetes-cncf/module-4/intro.md
@@ -11,7 +11,7 @@ Commonly the three components ElasticSearch, Fluentd, and Kibana (EFK) are combi
 In the following steps you will learn:
 
 - How to deploy ElasticSearch, Fluentd, and Kibana
-- How to generate log events and query then in Kibana
+- How to generate log events and query them in Kibana
 
 ## Forwarding: Fluent Bit ##
 

--- a/kubernetes-cncf/module-4/step4.md
+++ b/kubernetes-cncf/module-4/step4.md
@@ -15,4 +15,4 @@ Kibana will start in a few moments and you can observe its progress.
 
 Once complete, the _kibana_ pod will move to the _running_ state. It will be a few moments and the Deployments will eventually move to the _available (1)_ state. Use this ```clear```{{execute interrupt}} to ctrl-c and clear the shell or press ctrl-c to break out of the watch.
 
-You know have a full EFK stack running. Granted its smaller and not configure to he highly available or with access protection, but these 5 pods comprise is a functional solution to get started.
+You know have a full EFK stack running. Granted it's smaller and not configured to be highly available or with access protection, but these 5 pods comprise a functional solution to get started.

--- a/kubernetes-cncf/module-4/step6.md
+++ b/kubernetes-cncf/module-4/step6.md
@@ -15,7 +15,7 @@ To see the logs collected from the random-logger service follow these steps in t
 1. When Kibana appears for the first time there will be a brief animation while it initializes.
 1. On the Welcome page click **_Explore on my own_**.
 1. From the left-hand menu select the top **_Discover_** item.
-1. In the form field _Index pattern_ enter **_kubernetes_cluster-*_**
+1. In the form field _Index pattern_ enter **kubernetes_cluster-***
 1. It should read "Success!" and Click the **_> Next step_** button on the right.
 1. In the next form select **_timestamp_** from the dropdown labeled _Time Filter field name_.
 1. From the bottom-right of the form select **_Create index pattern_**.

--- a/kubernetes-cncf/module-7/assets/resources/constraint-template.yaml
+++ b/kubernetes-cncf/module-7/assets/resources/constraint-template.yaml
@@ -1,16 +1,16 @@
 # Derived from the example here: https://github.com/open-policy-agent/gatekeeper#constraint-templates
-apiVersion: templates.gatekeeper.sh/v1alpha1
+apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
-  name: requiredlabels
+  name: k8srequiredlabels
 spec:
   crd:
     spec:
       names:
-        kind: RequiredLabels
-        listKind: RequiredLabelsList
-        plural: requiredlabels
-        singular: requiredlabel
+        kind: K8sRequiredLabels
+        listKind: K8sRequiredLabelsList
+        plural: k8srequiredlabels
+        singular: k8srequiredlabel
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:
@@ -21,10 +21,11 @@ spec:
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |
-        package requiredlabels
-        deny[{"msg": msg, "details": {"missing_labels": missing}}] {
+        package k8srequiredlabels
+
+        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
           provided := {label | input.review.object.metadata.labels[label]}
-          required := {label | label := input.constraint.spec.parameters.labels[_]}
+          required := {label | label := input.parameters.labels[_]}
           missing := required - provided
           count(missing) > 0
           msg := sprintf("you must provide labels: %v", [missing])

--- a/kubernetes-cncf/module-7/assets/resources/constraint.yaml
+++ b/kubernetes-cncf/module-7/assets/resources/constraint.yaml
@@ -1,5 +1,5 @@
-apiVersion: constraints.gatekeeper.sh/v1alpha1
-kind: RequiredLabels
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRequiredLabels
 metadata:
   name: team-must-have-metadata
 spec:

--- a/kubernetes-cncf/module-7/env-init.sh
+++ b/kubernetes-cncf/module-7/env-init.sh
@@ -11,6 +11,6 @@ helm repo update
 
 # Setup OPA Gatekeeper - Policy Controller for Kubernetes
 kubectl create ns gatekeeper-system
-kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/deploy/gatekeeper-constraint.yaml
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/deploy/gatekeeper.yaml
 
 { clear && echo 'Kubernetes with OPA is ready.'; } 2> /dev/null

--- a/kubernetes-fundamentals-1/module-3/intro.md
+++ b/kubernetes-fundamentals-1/module-3/intro.md
@@ -10,7 +10,7 @@ Pods are *groups of containers with shared namespaces and shared volumes*.
 * Pods containers are always co-located on the same host
 * Pod containers share a single IP and portspace and communicate via localhost
 * Pod containers have access to shared volumes for storage
-* Pods are designed to be emphemeral (like cattle, not pets)
+* Pods are designed to be ephemeral (like cattle, not pets)
 
 In this lab we will explore the following:
 
@@ -26,7 +26,7 @@ In this exercise, we explore file based pod specification and creation.
 
 ## Inspecting Pods
 
-Understanding how a pod works will him you debig issues when they arrive.
+Understanding how a pod works will help you debug issues when they arrive.
 In this lab we will explore the Pod lifecycle, networking, and configuration.
 
 For more information, see the Kubernetes [documentation][docs].

--- a/kubernetes-fundamentals-2/module-6/assets/resources/values-override.yaml
+++ b/kubernetes-fundamentals-2/module-6/assets/resources/values-override.yaml
@@ -12,12 +12,12 @@ master:
 
 # List of plugins to be install during Jenkins master start
   installPlugins:
+    - structs:1.20
     - kubernetes:1.18.2
     - workflow-job:2.33
     - workflow-aggregator:2.6
     - credentials-binding:1.19
     - git:3.11.0
-    - structs:1.20
 
 agent:
   enabled: true

--- a/kubernetes-fundamentals-2/module-6/assets/resources/values-override.yaml
+++ b/kubernetes-fundamentals-2/module-6/assets/resources/values-override.yaml
@@ -12,12 +12,12 @@ master:
 
 # List of plugins to be install during Jenkins master start
   installPlugins:
-    - kubernetes:1.14.0
-    - workflow-job:2.31
+    - kubernetes:1.18.2
+    - workflow-job:2.33
     - workflow-aggregator:2.6
-    - credentials-binding:1.17
-    - git:3.9.1
-    - structs:1.18
+    - credentials-binding:1.19
+    - git:3.11.0
+    - structs:1.20
 
 agent:
   enabled: true

--- a/kubernetes-fundamentals-2/module-6/assets/resources/values-override.yaml
+++ b/kubernetes-fundamentals-2/module-6/assets/resources/values-override.yaml
@@ -4,7 +4,7 @@
 
 master:
   image: "jenkins/jenkins"
-  imageTag: "2.164.1-alpine"
+  imageTag: "2.190-alpine"
   useSecurity: false
   # Master.resources: {requests: {cpu: 50m, memory: 512Mi}, limits: {cpu: 2000m, memory: 2048Mi}}
   serviceType: NodePort


### PR DESCRIPTION
Addresses all the issues I submitted, except: 
1) There wasn't anything wrong with the vote section of KF2M5 (Ingresses) after all, it only displays "Service Unavailable" if you click through too fast
2) Can't fully fix KF2M6 Jenkins; feel free to discard those commits if you have a different direction in mind. 

Re: KF2M6, Updating the plugin versions and the Jenkins version, as well as specifying the structs plugin version first, resolves the issues of not being able to set up the pipeline, needing an executor (agent is now successfully created), and not being able to use kubectl. However, there is now an error message on all the apply's (services, canary, production): error validating data: the server could not find the requested resource. This persists even when using a fork with an api version matching the latest standard (apps/v1), and --validate=false on either will pass but result in no response to the CURL requests.

I assume this must have worked originally, but the non-overridden plugins are now versions that are not compatible with the overridden ones. So there might be a quick fix possible of adding overrides for the plugins with advanced dependencies, to bring them back to what they were at the time this lesson was written. I can try that later, though I'm not sure if that's the best approach versus bringing everything up to date (but I do not know how to do that fully, as I'm not sure where the conflict is at the point I got stuck).